### PR TITLE
do not match .j extension

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,7 +19,7 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /\.js?$/,
+        test: /\.js$/,
         exclude: /node_modules/,
         use: {
           loader: 'babel-loader',


### PR DESCRIPTION
This is a little pedantic of me, but there was an extra `?` in the test of the first rule in the webpack config.